### PR TITLE
feat(terraform): bootstrap remote state with S3 and DynamoDB

### DIFF
--- a/terraform/bootstrap/.terraform.lock.hcl
+++ b/terraform/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.33.0"
+  hashes = [
+    "h1:MxndtTQD9qHGQwIjScLlY4BQZgdjJ1Lsq1TdwodsxmU=",
+    "zh:207f3f9db05c11429a241b84deeecfbd4caa941792c2c49b09c8c85cd59474dd",
+    "zh:25c36ad1f4617aeb23f8cd18efc7856127db721f6cf3e2e474236af019ce9ad1",
+    "zh:2685af1f3eb9abfce3168777463eaaad9dba5687f9f84d8bb579cb878bcfa18b",
+    "zh:57e28457952cf43923533af0a9bb322164be5fc3d66c080b5c59ee81950e9ef6",
+    "zh:5b6cd074f9e3a8d91841e739d259fe11f181e69c4019e3321231b35c0dde08c8",
+    "zh:6e3251500cebf1effb9c68d49041268ea270f75b122b94d261af231a8ebfa981",
+    "zh:7eee56f52f4b94637793508f3e83f68855f5f884a77aed2bd2fe77480c89e33d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e228c92db1b9e36a0f899d6ab7446e6b8cf3183112d4f1c1613d6827a0ed3d6",
+    "zh:b34a84475e91715352ed1119b21e51a81d8ad12e93c86d4e78cd2d315d02dcab",
+    "zh:cdcc05a423a78a9b2c4e2844c58ecbf2ce6a3117cab353fa05197782d6f76667",
+    "zh:d0f5f6b1399cfa1b64f3e824bee9e39ff15d5a540ff197e9bfc157fe354a8426",
+    "zh:d9525dbb53468dee6b8e6d15669d25957e9872bf1cd386231dff93c8c659f1d7",
+    "zh:ed37db2df08b961a7fc390164273e602767ca6922f57560daa9678a2e1315fd0",
+    "zh:f6adc66b86e12041a2d3739600e6a153a1f5752dd363db11469f6f4dbd090080",
+  ]
+}

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,0 +1,18 @@
+resource "aws_s3_bucket" "tf_state" {
+  bucket = "vikas-healthcare-tf-state-2026-xyz123"
+
+  tags = {
+    Name = "terraform-state"
+  }
+}
+
+resource "aws_dynamodb_table" "tf_lock" {
+  name         = "terraform-lock-table"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}


### PR DESCRIPTION
### Summary
This PR introduces the Terraform bootstrap configuration to provision the remote state backend required for collaborative Infrastructure as Code workflows.

### Changes
- Added S3 bucket for Terraform remote state storage
- Added DynamoDB table for state locking
- Configured bootstrap AWS provider
- Established foundation for multi-environment deployments

### Why
Terraform remote state resources must exist before backend initialization. This bootstrap step ensures safe state management and prevents concurrent state corruption.

### Impact
- Enables GitOps-driven infrastructure deployments
- Provides state locking for team collaboration
- Prepares the environment for EKS infrastructure provisioning