### PR TITLE
fix(ci): add terraform plan back to PR CI with AWS credentials

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -3,6 +3,13 @@ name: PR CI
 on:
   pull_request:
 
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-south-1
+
 jobs:
   terraform_checks:
     runs-on: ubuntu-latest
@@ -15,17 +22,34 @@ jobs:
         with:
           terraform_version: 1.8.1
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Terraform fmt -check
         working-directory: terraform
         run: terraform fmt -check -recursive
 
       - name: Terraform init
         working-directory: terraform
-        run: terraform init -backend=false
+        run: terraform init
 
       - name: Terraform validate
         working-directory: terraform
         run: terraform validate
+
+      - name: Terraform plan (all environments)
+        working-directory: terraform
+        run: |
+          set -euo pipefail
+          for env in dev staging prod; do
+            echo "::group::terraform plan ${env}"
+            terraform workspace select -or-create ${env}
+            terraform plan -var-file=environments/${env}.tfvars -input=false
+            echo "::endgroup::"
+          done
 
   k8s_manifest_checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add AWS credential configuration via OIDC role
- Init with real S3 backend instead of -backend=false
- Plan against all environments (dev, staging, prod) using workspaces