### PR TITLE
feat(terraform): add single ECR repository for application images

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,3 +40,8 @@ module "eks" {
   node_min_size             = var.node_min_size
   node_max_size             = var.node_max_size
 }
+
+module "ecr" {
+  source      = "./modules/ecr"
+  environment = local.environment
+}

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -1,5 +1,5 @@
-resource "aws_ecr_repository" "patient" {
-  name                 = "healthcare-patient-service-${var.environment}"
+resource "aws_ecr_repository" "app" {
+  name                 = "healthcare-app-${var.environment}"
   image_tag_mutability = "MUTABLE"
 
   image_scanning_configuration {
@@ -7,21 +7,7 @@ resource "aws_ecr_repository" "patient" {
   }
 
   tags = {
-    Name        = "patient-service"
-    Environment = var.environment
-  }
-}
-
-resource "aws_ecr_repository" "appointment" {
-  name                 = "healthcare-appointment-service-${var.environment}"
-  image_tag_mutability = "MUTABLE"
-
-  image_scanning_configuration {
-    scan_on_push = true
-  }
-
-  tags = {
-    Name        = "appointment-service"
+    Service     = "healthcare-app"
     Environment = var.environment
   }
 }

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -1,6 +1,27 @@
-// Placeholder module for ECR registry per microservice.
-locals {
-  repository_url = "123456789012.dkr.ecr.us-east-1.amazonaws.com/app-placeholder"
+resource "aws_ecr_repository" "patient" {
+  name                 = "healthcare-patient-service-${var.environment}"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name        = "patient-service"
+    Environment = var.environment
+  }
 }
 
-# TODO: Implement aws_ecr_repository definition and lifecycle policies.
+resource "aws_ecr_repository" "appointment" {
+  name                 = "healthcare-appointment-service-${var.environment}"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name        = "appointment-service"
+    Environment = var.environment
+  }
+}

--- a/terraform/modules/ecr/outputs.tf
+++ b/terraform/modules/ecr/outputs.tf
@@ -1,4 +1,7 @@
-output "repository_url" {
-  description = "Placeholder repository URI"
-  value       = local.repository_url
+output "patient_repo_url" {
+  value = aws_ecr_repository.patient.repository_url
+}
+
+output "appointment_repo_url" {
+  value = aws_ecr_repository.appointment.repository_url
 }

--- a/terraform/modules/ecr/outputs.tf
+++ b/terraform/modules/ecr/outputs.tf
@@ -1,7 +1,3 @@
-output "patient_repo_url" {
-  value = aws_ecr_repository.patient.repository_url
-}
-
-output "appointment_repo_url" {
-  value = aws_ecr_repository.appointment.repository_url
+output "repository_url" {
+  value = aws_ecr_repository.app.repository_url
 }

--- a/terraform/modules/ecr/variables.tf
+++ b/terraform/modules/ecr/variables.tf
@@ -1,11 +1,4 @@
-variable "repository_name" {
-  description = "Logical ECR repository name"
+variable "environment" {
+  description = "Environment name"
   type        = string
-  default     = "app-placeholder"
-}
-
-variable "image_tag_mutability" {
-  description = "Tag mutability policy"
-  type        = string
-  default     = "MUTABLE"
 }


### PR DESCRIPTION
### Summary
Introduces a centralized Amazon ECR repository for storing application container images.

### Changes
- Created environment-scoped ECR repository
- Enabled image scanning on push for security
- Implemented via modular Terraform
- Validated using targeted Terraform apply

### Why
ECR is required to store container images that will be deployed to the EKS cluster.

### Impact
Provides secure and scalable container registry for the healthcare platform.

### Note
ECR resources are additive infrastructure.  
EKS and networking resources were not modified as part of this change.